### PR TITLE
Bump request

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pagerduty-incidents",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
[Retire](https://blog.liftsecurity.io/2014/11/19/bower-components-with-known-vulnerabilities) complains:

```
qs 0.6.6 has known vulnerabilities: https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking
pagerduty-incidents 0.0.2
 ↳ request 2.34.0
  ↳ qs 0.6.6
```

Bumping the request version to 2.51.0 helps.

/cc @ianshward 
